### PR TITLE
Integrate Dynamic Organization Info from Config

### DIFF
--- a/config_example/index.hjson
+++ b/config_example/index.hjson
@@ -11,6 +11,11 @@
     bind_method: ip
   }
 
+  organization: {
+    name: "Arbeitskreis Kultur und Kommunikation"
+    city: "Karlsruhe"
+  }
+  
   db: {
     // The path of the database file.
     uri: sqlite:db.sqlite

--- a/src/api/quittung.js
+++ b/src/api/quittung.js
@@ -1,9 +1,12 @@
 import express from 'express'
 import * as fs from 'fs';
 import n2words from 'n2words'
+import hjson from 'hjson';
 
 import setupLogging from '../logging.js'
 
+const config = hjson.parse(fs.readFileSync('config/index.hjson', 'utf8'));
+const organizationCity = config.organization.city;
 const log = setupLogging('db', 6)
 
 // globally available variables
@@ -55,7 +58,7 @@ function createQuittung (req, res) {
   // TODO start print pdf and print job
 
   // TODO create quittung number
-  const quittungNumber = '1337'
+  //const quittungNumber = '1337'
 
   Quittung.create({
     who_to: whoTo,
@@ -67,7 +70,10 @@ function createQuittung (req, res) {
     taxes: taxes,
     when: date
   })
-  .then(res.render('print_quittung', {
+  .then((quittung) => {
+    // Use the ID from the created quittung entry
+    const quittungNumber = quittung.id;
+    res.render('print_quittung', {
     quittung_number: quittungNumber,
     amount: amount,
     taxes: taxes,
@@ -76,8 +82,9 @@ function createQuittung (req, res) {
     who_from: whoFrom,
     who_to: whoTo,
     reason: reason,
-    date: date
-  }))
+    date: date,
+    organizationCity: organizationCity
+  })})
 }
 
 function checkRequest (r) {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,8 +1,14 @@
 import express from 'express'
+import hjson from 'hjson';
+import fs from 'fs';
+
+const config = hjson.parse(fs.readFileSync('config/index.hjson', 'utf8'));
+const organizationName = config.organization.name;
 
 function getQuittungForm (req, res) {
   res.render('add_quittung', {
-    title: 'Quittung'
+    title: 'Quittung',
+    organizationName: organizationName
   })
 }
 

--- a/src/views/add_quittung.pug
+++ b/src/views/add_quittung.pug
@@ -35,11 +35,11 @@ block content
   form(id='create_quittung', method='post', action='/api/quittung')
     div
       h2 Das Geld geht an…
-      +radio_label('who_to', 'to_us' ,'Arbeitskreis Kultur und Kommunikation', true, true)
+      +radio_label('who_to', 'to_us' ,organizationName, true, true)
       +radio_label('who_to', 'to_them')
     div
       h2 Das Geld kommt von…
-      +radio_label('who_from', 'from_us', 'Arbeitskreis Kultur und Kommunikation', true)
+      +radio_label('who_from', 'from_us', organizationName, true)
       +radio_label('who_from', 'from_them')
     h2 Das Geld ist für…
     div(id='to_us_section')

--- a/src/views/print_quittung.pug
+++ b/src/views/print_quittung.pug
@@ -39,7 +39,7 @@ block content
       td(align="right")
         h2 Ort
       td(align="left")
-        h2 Karlsruhe
+        h2 #{organizationCity}
       td(rowspan="2", colspan="3")
         h3 Diese Quittung wurde maschinell erstellt
         h3 und ist ohne Unterschrift gültig.


### PR DESCRIPTION
- Updated `index.hjson` to include new fields for the organization name and city.
- Modified `src/api/quittung.js` to replace hardcoded 'quittungNumber' with the ID from the SQLite database entry.
- Enhanced `add_quittung.pug` to dynamically display the organization name from the configuration file instead of a hardcoded string.

These changes ensure that the organization name and city is configurable 
The `quittungNumber` now correctly reflects the database entry ID.